### PR TITLE
Add a command to generate an API token

### DIFF
--- a/app/Console/Commands/CreateApiToken.php
+++ b/app/Console/Commands/CreateApiToken.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class CreateApiToken extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:create_api_token {email} {token_name?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new API token for a user.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $email = $this->argument('email');
+        $user = User::where('email', $email)->first();
+        $tokenName = $this->argument('token_name') ?? sprintf('%s API Token', $email);
+
+        if (!$user) {
+            $this->error(sprintf(
+                'User with email "%s" not found. Try %s/register',
+                $email,
+                env('APP_URL', 'localhost'),
+            ));
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $token = $user->createToken($tokenName);
+
+            $this->info(sprintf(
+                'API token (%s) created for user %s: %s',
+                $tokenName,
+                $email,
+                $token->plainTextToken
+            ));
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error(sprintf('Unable to generate token: %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+    }
+}


### PR DESCRIPTION
This command will generate an API token for a user. In the future, this should be handled through the UI (probably in a user profile?) but this is just to get things up and running quickly from the command line.

Usage:
1. Go to localhost/register and create a user
2. 
```
# if using sail/docker:
sail artisan command:create_api_token you@example.com

# if not using sail/docker
artisan command.create_api_token you@example.com
```