### PR TITLE
Add API resources/endpoints

### DIFF
--- a/app/Http/Resources/NoteCollection.php
+++ b/app/Http/Resources/NoteCollection.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Resources;
 
-use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 
-class Note extends JsonResource
+class NoteCollection extends ResourceCollection
 {
     /**
-     * Transform the resource into an array.
+     * Transform the resource collection into an array.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable

--- a/app/Http/Resources/NoteResource.php
+++ b/app/Http/Resources/NoteResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class NoteResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,19 +21,6 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-//Route::middleware('auth:sanctum')
-//    ->get('/notes', function (Request $request) {
-//        $notes = Note::all()
-//            ->where(['user_id', $request->user()->id]);
-//
-//        return new NoteCollection($notes);
-//    })
-//    ->get('notes/{id}', function (Request $request) {
-//        $note = Note::where(['user_id', $request->user()->id]);
-//
-//        return NoteResource($note);
-//    });
-
 Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::get('/notes', function (Request $request) {
         $notes = Note::all()

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Resources\NoteCollection;
+use App\Http\Resources\NoteResource;
+use App\Models\Note;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -16,4 +19,32 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+//Route::middleware('auth:sanctum')
+//    ->get('/notes', function (Request $request) {
+//        $notes = Note::all()
+//            ->where(['user_id', $request->user()->id]);
+//
+//        return new NoteCollection($notes);
+//    })
+//    ->get('notes/{id}', function (Request $request) {
+//        $note = Note::where(['user_id', $request->user()->id]);
+//
+//        return NoteResource($note);
+//    });
+
+Route::group(['middleware' => ['auth:sanctum']], function () {
+    Route::get('/notes', function (Request $request) {
+        $notes = Note::all()
+            ->where('user_id', $request->user()->id);
+
+        return new NoteCollection($notes);
+    });
+
+    Route::get('notes/{id}', function (Request $request) {
+        $note = Note::where('user_id', $request->user()->id)->first();
+
+        return new NoteResource($note);
+    });
 });


### PR DESCRIPTION
This just adds a collection for notes + a resource for a single note to
be serialized/formatted for the API.

I had previously stubbed out the resource object for `Note`, but it
looks like the correct convention is to use a `Resource` suffix, and a
`Collection` suffix in laravel, so I changed it to match that
convention.

Right now this only provides HTTP GET endpoints to pull a single note
and all notes.

By default this will only pull notes that are associated to the
authenticated user.