### PR TITLE
Add ability to create a note via API

### DIFF
--- a/app/ApiExceptionDTO.php
+++ b/app/ApiExceptionDTO.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+namespace App;
+
+final class APIExceptionDTO
+{
+    /**
+     * @param string $message the exception message/error message
+     * @param array $errors the specific errors associated to the action
+     * @see \App\Exception\APIException
+     */
+    public function __construct(
+        public string $message = 'Unable to process request.',
+        public array $errors = []
+    ) {}
+}

--- a/app/Exceptions/ApiException.php
+++ b/app/Exceptions/ApiException.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+namespace App\Exceptions;
+
+use App\APIExceptionDTO;
+use Illuminate\Http\Response;
+
+class ApiException extends \Exception
+{
+    public const MESSAGE_KEY = 'message';
+
+    public const ERRORS_KEY = 'errors';
+
+    /**
+     * @var APIExceptionDTO
+     */
+    private $dto;
+
+    /**
+     * @param string $message the exception message
+     * @param int $code the http status code
+     * @param \Throwable $previous the previous throwable for exception chaining
+     */
+    public function __construct(APIExceptionDTO $dto, int $code, \Throwable $previous = null)
+    {
+        $this->dto = $dto;
+
+        parent::__construct($dto->message, $code, $previous);
+    }
+
+    /**
+     * Render this exception as an HTTP response.
+     *
+     * @return Response
+     */
+    public function render(): Response
+    {
+        $body = [
+            self::MESSAGE_KEY => $this->dto->message,
+            self::ERRORS_KEY => $this->dto->errors,
+        ];
+
+        return new Response($body, $this->getCode());
+    }
+}

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+namespace App\Http\Controllers\Api;
+
+use App\ApiExceptionDTO;
+use App\Exceptions\ApiException;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+
+abstract class ApiController extends Controller
+{
+    /**
+     * Return a 201 with an empty response body. Use this when a new resource is created.
+     *
+     * @return Response
+     */
+    protected function newResourceCreatedResponse(): Response
+    {
+        return new Response('', 201);
+    }
+
+    /**
+     * @param array $errors the errors to add to the response
+     * @return void
+     */
+    protected function throw(string $message, array $errors = [], $statusCode = 400): void
+    {
+        throw new ApiException(new ApiExceptionDTO($message, $errors), $statusCode);
+    }
+}

--- a/app/Http/Controllers/Api/CreateNoteController.php
+++ b/app/Http/Controllers/Api/CreateNoteController.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+namespace App\Http\Controllers\Api;
+
+use App\Exceptions\ApiException;
+use App\Models\Note;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class CreateNoteController extends ApiController
+{
+    /**
+     * Create a new note.
+     *
+     * @return Response
+     */
+    public function create(Request $request): Response
+    {
+        $title = $request->input('title');
+        $note = $request->input('note');
+
+        if (!$title) {
+            $this->throw('Missing required params', ['title' => 'Required']);
+        }
+
+        if (!$note) {
+            $this->throw('Missing required params', ['note' => 'Required']);
+        }
+
+        $entity = new Note();
+        $entity->setAttribute('title', $title);
+        $entity->setAttribute('note', $note);
+        $entity->setAttribute('user_id', $request->user()->id);
+
+        try {
+            $entity->saveOrFail();
+        } catch (\Throwable $e) {
+            $this->throw('Unable to save note.');
+            // FIXME probably best to log something here since we aren't surfacing the real problem to the user
+        }
+
+        return $this->newResourceCreatedResponse();
+    }
+}

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -10,6 +10,11 @@ class Note extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'title',
+        'note',
+    ];
+
     /**
      * @return BelongsTo
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\CreateNoteController;
 use App\Http\Resources\NoteCollection;
 use App\Http\Resources\NoteResource;
 use App\Models\Note;
@@ -34,4 +35,6 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
 
         return new NoteResource($note);
     });
+
+    Route::post('notes', [CreateNoteController::class, 'create']);
 });


### PR DESCRIPTION
The idea here is to have a single controller per action so that the
controllers can have single responsibility.

The abstract ApiController exists so that we can have an easy way to
return common types of responses (success/error, etc).

To assist with error responses, there is a new ApiException class, which
implements a `render()` method. Laravel uses this behind the scenes to
render the exception as an HTTP response.

To assist the exception there is a DTO just to encapsulate a message +
errors. This might change, but it gets the job done for now.

I'm not sure if this is idiomatic/laravel convention, and if there is a
better way I'm happy to improve it.