### PR TITLE
Add missing API endpoints

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -20,6 +20,16 @@ abstract class ApiController extends Controller
     }
 
     /**
+     * Return a 204 with an empty response body. Use this when a resource is deleted.
+     *
+     * @return Response
+     */
+    protected function newResourceDeletedResponse(): Response
+    {
+        return new Response('', 204);
+    }
+
+    /**
      * @param array $errors the errors to add to the response
      * @return void
      */

--- a/app/Http/Controllers/Api/DeleteNoteController.php
+++ b/app/Http/Controllers/Api/DeleteNoteController.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+namespace App\Http\Controllers\Api;
+
+use App\Exceptions\ApiException;
+use App\Models\Note;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class DeleteNoteController extends ApiController
+{
+    /**
+     * Create a new note.
+     *
+     * @return Response
+     */
+    public function handle(Request $request): Response
+    {
+        $conditions = [
+            'user_id' => $request->user()->id,
+            'id' => $request->id,
+        ];
+
+        $note = Note::where($conditions)->first();
+
+        if (!$note) {
+            $this->throw('Note not found.', [], 404);
+        }
+
+        try {
+            $note->deleteOrFail();
+        } catch (\Throwable $e) {
+            throw $e;
+            $this->throw('Unable to delete note.');
+            // FIXME probably best to log something here since we aren't surfacing the real problem to the user
+        }
+
+        return $this->newResourceDeletedResponse();
+    }
+}

--- a/app/Http/Controllers/Api/NotesController.php
+++ b/app/Http/Controllers/Api/NotesController.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+namespace App\Http\Controllers\Api;
+
+use App\Exceptions\ApiException;
+use App\Http\Resources\NoteCollection;
+use App\Http\Resources\NoteResource;
+use App\Models\Note;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class NotesController extends ApiController
+{
+    /**
+     * Create a new note.
+     *
+     * @return Response
+     */
+    public function handle(Request $request): Response
+    {
+        $conditions = [
+            'user_id' => $request->user()->id,
+        ];
+
+        $note = Note::all()->where($conditions);
+
+        return (new NoteCollection($notes))
+            ->toResponse($request);
+    }
+}

--- a/app/Http/Controllers/Api/ViewNoteController.php
+++ b/app/Http/Controllers/Api/ViewNoteController.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+namespace App\Http\Controllers\Api;
+
+use App\Exceptions\ApiException;
+use App\Http\Resources\NoteResource;
+use App\Models\Note;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ViewNoteController extends ApiController
+{
+    /**
+     * Create a new note.
+     *
+     * @return Response
+     */
+    public function handle(Request $request): Response
+    {
+        $conditions = [
+            'user_id' => $request->user()->id,
+            'id' => $request->id,
+        ];
+
+        $note = Note::where($conditions)->first();
+
+        if (!$note) {
+            $this->throw('Note not found.', [], 404);
+        }
+
+        return (new NoteResource($note))
+            ->toResponse($request);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        JsonResource::withoutWrapping();
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Http\Controllers\Api\CreateNoteController;
+use App\Http\Controllers\Api\DeleteNoteController;
+use App\Http\Controllers\Api\UpdateNoteController;
+use App\Http\Controllers\Api\ViewNoteController;
 use App\Http\Resources\NoteCollection;
 use App\Http\Resources\NoteResource;
 use App\Models\Note;
@@ -30,11 +33,8 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         return new NoteCollection($notes);
     });
 
-    Route::get('notes/{id}', function (Request $request) {
-        $note = Note::where('user_id', $request->user()->id)->first();
-
-        return new NoteResource($note);
-    });
-
-    Route::post('notes', [CreateNoteController::class, 'create']);
+    Route::get('notes/{id}', [ViewNoteController::class, 'handle']);
+    Route::post('notes', [CreateNoteController::class, 'handle']);
+    Route::patch('notes/{id}', [UpdateNoteController::class, 'handle']);
+    Route::delete('notes/{id}', [DeleteNoteController::class, 'handle']);
 });


### PR DESCRIPTION
This adds the update, view, and list/index methods.

I decided to make a separate controller for every method, even the
view/index which were previously handled directly in the routes file.

It seems cleaner for all of the endpoints to be structured the same way
instead of having the magic.

This also sneaks in a fix for the previous view endpoint that was not
scoping the query to the current user (oops).

Finally, there is a change in the AppServiceProvider that removes the
default "wrapping" of the json response with `data`. I'm not sure what
the benefit of that is, so it's been removed for now.