### PR TITLE
Add validation and clean up controllers

### DIFF
--- a/app/EntityErrorInterface.php
+++ b/app/EntityErrorInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+namespace App;
+
+interface EntityErrorInterface
+{
+    /**
+     * @return array
+     */
+    public function getRules(): array;
+
+    /**
+     * @return errors;
+     */
+    public function getErrors(): array;
+}

--- a/app/Http/Controllers/Api/CreateNoteController.php
+++ b/app/Http/Controllers/Api/CreateNoteController.php
@@ -28,16 +28,16 @@ final class CreateNoteController extends ApiController
             $this->throw('Missing required params', ['note' => 'Required']);
         }
 
-        $entity = new Note();
-        $entity->setAttribute('title', $title);
-        $entity->setAttribute('note', $note);
-        $entity->setAttribute('user_id', $request->user()->id);
+        $data = [
+            'title' => $title,
+            'note' => $note,
+            'user_id' => $request->user()->id,
+        ];
 
-        try {
-            $entity->saveOrFail();
-        } catch (\Throwable $e) {
-            $this->throw('Unable to save note.');
-            // FIXME probably best to log something here since we aren't surfacing the real problem to the user
+        $entity = new Note($data);
+
+        if (!$entity->save()) {
+            $this->throw('Unable to save note.', $entity->getErrors(), 400);
         }
 
         return $this->newResourceCreatedResponse();

--- a/app/Http/Controllers/Api/DeleteNoteController.php
+++ b/app/Http/Controllers/Api/DeleteNoteController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 final class DeleteNoteController extends ApiController
 {
     /**
-     * Create a new note.
+     * Delete a note.
      *
      * @return Response
      */

--- a/app/Http/Controllers/Api/NotesController.php
+++ b/app/Http/Controllers/Api/NotesController.php
@@ -13,8 +13,9 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 final class NotesController extends ApiController
 {
     /**
-     * Create a new note.
+     * Retrieve all notes.
      *
+     * FIXME: pagination would be nice
      * @return Response
      */
     public function handle(Request $request): Response

--- a/app/Http/Controllers/Api/UpdateNoteController.php
+++ b/app/Http/Controllers/Api/UpdateNoteController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 final class UpdateNoteController extends ApiController
 {
     /**
-     * Create a new note.
+     * Update a note.
      *
      * @return Response
      */
@@ -29,18 +29,11 @@ final class UpdateNoteController extends ApiController
             $this->throw('Note not found', [], 404);
         }
 
-        $title = $request->input('title');
-        $note = $request->input('note');
+        $entity->title = $request->input('title');
+        $entity->note = $request->input('note');
 
-        $entity->setAttribute('title', $title);
-        $entity->setAttribute('note', $note);
-        $entity->setAttribute('user_id', $request->user()->id);
-
-        try {
-            $entity->saveOrFail();
-        } catch (\Throwable $e) {
-            $this->throw('Unable to save note.');
-            // FIXME probably best to log something here since we aren't surfacing the real problem to the user
+        if (!$entity->save()) {
+            $this->throw('Unable to update note.', $entity->getErrors(), 400);
         }
 
         return (new NoteResource($entity))

--- a/app/Http/Controllers/Api/ViewNoteController.php
+++ b/app/Http/Controllers/Api/ViewNoteController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 final class ViewNoteController extends ApiController
 {
     /**
-     * Create a new note.
+     * View a note.
      *
      * @return Response
      */

--- a/app/Http/Requests/NoteRequest.php
+++ b/app/Http/Requests/NoteRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class NoteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:50',
+            'note' => 'nullable|max:1000',
+        ];
+    }
+}

--- a/app/Models/AbstractModel.php
+++ b/app/Models/AbstractModel.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+namespace App\Models;
+
+use App\EntityErrorInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+abstract class AbstractModel extends Model implements EntityErrorInterface
+{
+    protected $errors = [];
+
+    protected $rules = [];
+
+    public function setErrors(array $errors): self
+    {
+        $this->errors = $errors;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        // pass the entity data through validation before saving
+        // we set an errors array if there are validation issues
+        $validate = function ($model) {
+            $validator = Validator::make($model->toArray(), $model->getRules());        
+
+            if ($validator->fails()) {
+                $model->setErrors($validator->getMessageBag()->getMessages());
+
+                return false;
+            }
+        };
+
+        self::creating($validate);
+        self::updating($validate);
+    }
+}

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -2,18 +2,28 @@
 
 namespace App\Models;
 
+use App\Http\Requests\NoteRequest;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class Note extends Model
+class Note extends AbstractModel
 {
     use HasFactory;
 
     protected $fillable = [
         'title',
         'note',
+        'user_id',
     ];
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRules(): array
+    {
+        return (new NoteRequest())->rules();
+    }
 
     /**
      * @return BelongsTo

--- a/database/migrations/2021_11_19_162741_create_notes_table.php
+++ b/database/migrations/2021_11_19_162741_create_notes_table.php
@@ -16,7 +16,7 @@ class CreateNotesTable extends Migration
         Schema::create('notes', function (Blueprint $table) {
             $table->id();
             $table->string('title', 50);
-            $table->text('note');
+            $table->text('note')->nullable();
             $table->integer('user_id');
 
             $table->index(['user_id']);


### PR DESCRIPTION
This adds some validation:
    - note titles are required and must not be more than 50 characters
    - note bodies (`note`) are not required but must not be more than
      1000 chararacters

I believe the convention in Laravel is to validate request data up
front, rather than at the model level, but it seems safer to apply the
validation just before saving at the model layer as well. This will
better ensure data integrity if the request data does not come from an
HTTP request (a CLI command for example?).

In order to do this, the following interface was added:
`EntityErrorInterface` (there might be a better name?). The idea here is
that any object that implements this interface has to provide a
`getErrors()` and a `getRules()` method.  This has been implemented in
an abstract class (`AbstractModel`) that the tables can extend.

The `AbstractModel` hooks into the `creating` and `updating` model
lifecycle events and checks the data for errors before saving. If it
detects validation errors, it sets them as an `$errors` property and
returns false to prevent the save. The calling code can then call
`getErrors()` to present the validation errors in any context.

Since the convention in Laravel seems to be to create subclasses of
`FormRequest` for defining these rules, that's what I've done. This will
also allow the above pattern to be ditched if it needs to be in factor
of simply validating request data.

There was also a change to the existing migration. The `note` field is
now nullable as it's not required. Normally, this kind of change would
be a separate migration, but there's no existing data or use of this
besides me so the existing migration was simply modified.

The rest of the changes here are minor bug fixes from manually running
the API calls.