### PR TITLE
Add integration tests

### DIFF
--- a/app/Http/Controllers/Api/UpdateNoteController.php
+++ b/app/Http/Controllers/Api/UpdateNoteController.php
@@ -29,8 +29,22 @@ final class UpdateNoteController extends ApiController
             $this->throw('Note not found', [], 404);
         }
 
-        $entity->title = $request->input('title');
-        $entity->note = $request->input('note');
+        $title = $request->input('title');
+        $note = $request->input('note');
+
+        // early return/no-op if there is nothing to patch
+        if (!$title && !$note) {
+            return (new NoteResource($entity))
+                ->toResponse($request);
+            }
+
+        if ($title) {
+            $entity->title = $title;
+        }
+
+        if ($note) {
+            $entity->note = $note;
+        }
 
         if (!$entity->save()) {
             $this->throw('Unable to update note.', $entity->getErrors(), 400);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -40,6 +40,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
+            //'auth.basic',
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/';
 
     /**
      * The controller namespace for the application.

--- a/database/factories/NoteFactory.php
+++ b/database/factories/NoteFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class NoteFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'tokenable_type' => 2,
+            'name' => 'testy.mctestface@example.com',
+            'token' => '2fb7d93a6849a004e4a84efda5d0eb121dafb00a7cdbd5dcec2fff0b57c5a90e',
+            'abilities' => ['*'],
+            'last_used_at' => null,
+            'created_at' => (new Carbon())->subMonth(),
+            'updated_at' => (new Carbon())->subMonth(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Resources\NoteCollection;
 use App\Http\Resources\NoteResource;
 use App\Models\Note;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 
 /*

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,6 +3,8 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Artisan;
 
 trait CreatesApplication
 {
@@ -16,7 +18,18 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+        $this->clearConfigCache();
 
         return $app;
     }
+
+    /**
+     * Clear config cache for tests.
+     * @return void
+     */
+    private function clearConfigCache(): void
+    {
+        Artisan::call('config:clear');
+    }
+
 }

--- a/tests/Feature/Api/CreateNoteControllerTest.php
+++ b/tests/Feature/Api/CreateNoteControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature\Api;
+
+use App\Models\Note;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Tests\Feature\ApiTestCase;
+use Tests\TestCase;
+
+final class CreateNoteControllerTest extends ApiTestCase
+{
+    public function testRequiresAuthentication(): void
+    {
+        $this->assertFalse($this->isAuthenticated());
+        $response = $this->json('POST', '/api/notes', ['note' => 'asdfsadfasdf', 'title' => 'asdfasdfasdf']);
+
+        $response->assertStatus(401);
+        $this->assertEquals(json_encode(['message' => 'Unauthenticated.']), $response->getContent());
+    }
+
+    public function testCanCreateNote(): void
+    {
+        $data = [
+            'note' => 'Test Note',
+            'title' => 'Test Title',
+        ];
+
+        $response = $this->withFakeAuthentication()->json('POST', '/api/notes', $data);
+
+        $response->assertStatus(201);
+        $note = Note::where(['user_id' => self::FAKE_USER_ID])->first();
+
+        $this->assertEquals($data['note'], $note->note);
+        $this->assertEquals($data['title'], $note->title);
+        $this->assertEquals(self::FAKE_USER_ID, $note->user_id);
+    }
+
+    public function testPassingAUserIdHasNoEffect(): void
+    {
+        $data = [
+            'note' => 'Test Note',
+            'title' => 'Test Title',
+            'user_id' => 999,
+        ];
+
+        $response = $this->withFakeAuthentication()->json('POST', '/api/notes', $data);
+
+        $response->assertStatus(201);
+        $notes = Note::all()->toArray();
+        $this->assertCount(1, $notes);
+        $note = $notes[0] ?? null;
+        $this->assertNotNull($note);
+
+        $this->assertEquals($data['note'], $note['note']);
+        $this->assertEquals($data['title'], $note['title']);
+        $this->assertEquals(self::FAKE_USER_ID, $note['user_id']); // make sure it's not 999
+    }
+}

--- a/tests/Feature/Api/DeleteNoteControllerTest.php
+++ b/tests/Feature/Api/DeleteNoteControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature\Api;
+
+use App\Models\Note;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Tests\Feature\ApiTestCase;
+use Tests\TestCase;
+
+final class DeleteNoteControllerTest extends ApiTestCase
+{
+    public function testRequiresAuthentication(): void
+    {
+        $this->assertFalse($this->isAuthenticated());
+        $response = $this->json('DELETE', '/api/notes/1');
+
+        $response->assertStatus(401);
+        $this->assertEquals(json_encode(['message' => 'Unauthenticated.']), $response->getContent());
+    }
+
+    /**
+     * @group curr
+     */
+    public function testCanDeleteOwnNote(): void
+    {
+        $data = [
+            'note' => 'Test Note 1',
+            'title' => 'Test Title 1',
+            'user_id' => self::FAKE_USER_ID,
+        ];
+
+        $note = new Note($data);
+        $note->saveOrFail();
+
+        $this->assertCount(1, Note::all()->toArray());
+
+        $note = Note::where(['user_id' => 42])->first();
+
+        $response = $this->withFakeAuthentication()->json('DELETE', sprintf('/api/notes/%d', $note->id));
+        $response->assertStatus(204);
+        $this->assertEmpty($response->getContent());
+    }
+
+    /**
+     * @group curr
+     */
+    public function testCannotDeleteSomeoneElsesNote(): void
+    {
+        $otherUserId = self::FAKE_USER_ID + 1;
+
+        $data = [
+            'note' => 'Test Note 1',
+            'title' => 'Test Title 1',
+            'user_id' => $otherUserId,
+        ];
+
+        $note = new Note($data);
+        $note->saveOrFail();
+
+        $this->assertCount(1, Note::all()->toArray());
+
+        $note = Note::where(['user_id' => $otherUserId])->first();
+
+        $response = $this->withFakeAuthentication()->json('DELETE', sprintf('/api/notes/%d', $note->id));
+        $response->assertStatus(404); // it gives a 404 so as not to indicate that it might exist
+
+        $expected = [
+            'message' => 'Note not found.',
+            'errors' => [],
+        ];
+
+        $this->assertEquals(json_encode($expected), $response->getContent());
+    }
+}

--- a/tests/Feature/Api/NoteControllerTest.php
+++ b/tests/Feature/Api/NoteControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature\Api;
+
+use App\Models\Note;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Tests\Feature\ApiTestCase;
+use Tests\TestCase;
+
+final class NoteControllerTest extends ApiTestCase
+{
+    public function testRequiresAuthentication(): void
+    {
+        $this->assertFalse($this->isAuthenticated());
+        $response = $this->json('GET', '/api/notes/1');
+
+        $response->assertStatus(401);
+        $this->assertEquals(json_encode(['message' => 'Unauthenticated.']), $response->getContent());
+    }
+
+    /**
+     * @group curr
+     */
+    public function testCanOnlyViewOwnNote(): void
+    {
+        // some setup for this test. We create 2 notes for the authenticated user, then two notes that don't belong to
+        // them. We want to ensure that only their notes are returned here
+        $notes = [
+            [
+                'note' => 'Test Note 1',
+                'title' => 'Test Title 1',
+                'user_id' => self::FAKE_USER_ID,
+            ],
+            [
+                'note' => 'Test Note 2',
+                'title' => 'Test Title 2',
+                'user_id' => self::FAKE_USER_ID,
+            ],
+        ];
+
+        $otherUserNotes = [
+            [
+                'note' => 'Test Other User Note 1',
+                'title' => 'Test Other User Title 1',
+                'user_id' => self::FAKE_USER_ID + 1,
+            ],
+            [
+                'note' => 'Test Other User Note 2',
+                'title' => 'Test Other User Title 2',
+                'user_id' => self::FAKE_USER_ID + 1,
+            ],
+        ];
+
+        foreach ($notes as $data) {
+            $note = new Note($data);
+            $note->saveOrFail();
+        }
+
+        foreach ($otherUserNotes as $data) {
+            $note = new Note($data);
+            $note->saveOrFail();
+        }
+
+        $notes = Note::all()
+            ->pluck('user_id')
+            ->toArray();
+
+        // just make sure that we did in fact create 4 notes, 2 for each user ID (42, and 43)
+        $expected = [
+            42,
+            42,
+            43,
+            43,
+        ];
+
+        $this->assertEquals($expected, $notes);
+
+        $note = Note::where(['user_id' => 42])->first();
+
+        $response = $this->withFakeAuthentication()->json('GET', sprintf('/api/notes/%d', $note->id));
+        $response->assertStatus(200);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertEquals($note->id, $data['id']);
+        $this->assertEquals(self::FAKE_USER_ID, $data['user_id']);
+    }
+}

--- a/tests/Feature/Api/NotesControllerTest.php
+++ b/tests/Feature/Api/NotesControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature\Api;
+
+use App\Models\Note;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Tests\Feature\ApiTestCase;
+use Tests\TestCase;
+
+final class NotesControllerTest extends ApiTestCase
+{
+    public function testRequiresAuthentication(): void
+    {
+        $this->assertFalse($this->isAuthenticated());
+        $response = $this->json('GET', '/api/notes');
+
+        $response->assertStatus(401);
+        $this->assertEquals(json_encode(['message' => 'Unauthenticated.']), $response->getContent());
+    }
+
+    /**
+     * @group curr
+     */
+    public function testCanOnlyViewOwnNotes(): void
+    {
+        // some setup for this test. We create 2 notes for the authenticated user, then two notes that don't belong to
+        // them. We want to ensure that only their notes are returned here
+        $notes = [
+            [
+                'note' => 'Test Note 1',
+                'title' => 'Test Title 1',
+                'user_id' => self::FAKE_USER_ID,
+            ],
+            [
+                'note' => 'Test Note 2',
+                'title' => 'Test Title 2',
+                'user_id' => self::FAKE_USER_ID,
+            ],
+        ];
+
+        $otherUserNotes = [
+            [
+                'note' => 'Test Other User Note 1',
+                'title' => 'Test Other User Title 1',
+                'user_id' => self::FAKE_USER_ID + 1,
+            ],
+            [
+                'note' => 'Test Other User Note 2',
+                'title' => 'Test Other User Title 2',
+                'user_id' => self::FAKE_USER_ID + 1,
+            ],
+        ];
+
+        foreach ($notes as $data) {
+            $note = new Note($data);
+            $note->saveOrFail();
+        }
+
+        foreach ($otherUserNotes as $data) {
+            $note = new Note($data);
+            $note->saveOrFail();
+        }
+
+        $notes = Note::all()
+            ->pluck('user_id')
+            ->toArray();
+
+        // just make sure that we did in fact create 4 notes, 2 for each user ID (42, and 43)
+        $expected = [
+            42,
+            42,
+            43,
+            43,
+        ];
+
+        $this->assertEquals($expected, $notes);
+
+        $response = $this->withFakeAuthentication()->json('GET', '/api/notes');
+        $response->assertStatus(200);
+        $data = collect(json_decode($response->getContent(), true))
+            ->pluck('user_id', 'title')
+            ->toArray();
+
+        $expected = [
+            'Test Title 1' => 42,
+            'Test Title 2' => 42,
+        ];
+
+        $this->assertEquals($expected, $data);
+    }
+}

--- a/tests/Feature/Api/UpdateNoteControllerTest.php
+++ b/tests/Feature/Api/UpdateNoteControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature\Api;
+
+use App\Models\Note;
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Tests\Feature\ApiTestCase;
+use Tests\TestCase;
+
+final class UpdateNoteControllerTest extends ApiTestCase
+{
+    public function testRequiresAuthentication(): void
+    {
+        $this->assertFalse($this->isAuthenticated());
+        $response = $this->json('PATCH', '/api/notes/1', ['something' => 'doesnt matter']);
+
+        $response->assertStatus(401);
+        $this->assertEquals(json_encode(['message' => 'Unauthenticated.']), $response->getContent());
+    }
+
+    public function testCanUpdateOwnNote(): void
+    {
+        $data = [
+            'note' => 'Test Note 1',
+            'title' => 'Test Title 1',
+            'user_id' => self::FAKE_USER_ID,
+        ];
+
+        $note = new Note($data);
+        $note->saveOrFail();
+
+        $this->assertCount(1, Note::all()->toArray());
+
+        $note = Note::where(['user_id' => 42])->first();
+
+        $response = $this->withFakeAuthentication()->json('GET', sprintf('/api/notes/%d', $note->id));
+        $response->assertStatus(200);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertEquals($note->id, $data['id']);
+        $this->assertEquals(self::FAKE_USER_ID, $data['user_id']);
+    }
+
+    public function testCannotUpdateSomeoneElsesNote(): void
+    {
+        $otherUserId = self::FAKE_USER_ID + 1;
+
+        $data = [
+            'note' => 'Test Note 1',
+            'title' => 'Test Title 1',
+            'user_id' => $otherUserId,
+        ];
+
+        $note = new Note($data);
+        $note->saveOrFail();
+
+        $this->assertCount(1, Note::all()->toArray());
+
+        $note = Note::where(['user_id' => $otherUserId])->first();
+
+        $response = $this->withFakeAuthentication()->json('GET', sprintf('/api/notes/%d', $note->id));
+        $response->assertStatus(404); // it gives a 404 so as not to indicate that it might exist
+
+        $expected = [
+            'message' => 'Note not found.',
+            'errors' => [],
+        ];
+
+        $this->assertEquals(json_encode($expected), $response->getContent());
+    }
+
+    /**
+     * @group curr2
+     */
+    public function testPassingAUserIdHasNoEffect(): void
+    {
+        // first we create our note to edit later
+        $data = [
+            'note' => 'Test Note 1',
+            'title' => 'Test Title 1',
+            'user_id' => self::FAKE_USER_ID,
+        ];
+
+        $note = new Note($data);
+        $note->saveOrFail();
+
+        $this->assertCount(1, Note::all()->toArray());
+
+        $note = Note::where(['user_id' => 42])->first();
+
+        // attempt to change the user_id to someone else
+        $data = [
+            'user_id' => 999,
+        ];
+
+        $response = $this->withFakeAuthentication()->json('PATCH', sprintf('/api/notes/%d', $note->id), $data);
+
+        // this should just be a no-op
+        $response->assertStatus(200);
+        $notes = Note::all()->toArray();
+        $this->assertCount(1, $notes);
+
+        $originalNote = $note;
+        $note = $notes[0] ?? null;
+        $this->assertNotNull($note);
+
+        $this->assertEquals($originalNote->note, $note['note']);
+        $this->assertEquals($originalNote->title, $note['title']);
+        $this->assertEquals($originalNote->user_id, $note['user_id']); // make sure it's not 999
+    }
+}

--- a/tests/Feature/ApiTestCase.php
+++ b/tests/Feature/ApiTestCase.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+namespace Tests\Feature;
+
+use App\Models\User;
+use Tests\TestCase;
+
+abstract class ApiTestCase extends TestCase
+{
+    public const FAKE_USER_ID = 42;
+
+    /**
+     * Pull the first api token from the database and inject it into the headers of the test HTTP request.
+     *
+     * Usage in a test:
+     * ```
+     * $response = $this->authenticated()->json('/api/something', ['data' => 'here']);
+     * // assert something about the response
+     * ```
+     *
+     * FIXME: there is probably a better way than disabling all middleware. Ideally we would inject a user + token into
+     * the test database, and inject the Bearer header?
+     *
+     * @return self
+     */
+    public function withFakeAuthentication(): self
+    {
+        return $this->withoutMiddleware()
+            ->actingAs(User::factory()->make(['id' => self::FAKE_USER_ID]));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,13 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
+    use DatabaseTransactions;
     use CreatesApplication;
+    //use RefreshDatabase;
 }


### PR DESCRIPTION
This adds tests for all endpoints:
    - create note
    - update note
    - delete note
    - view notes
    - view note

The `ApiTestCase` just adds a helper method to inject a user into the
request to bypass authentication in the test environment for cases where
we aren't testing the implementation detail of authentication.

The `NoteFactory` might not be needed, but I created it when I was
looking at how the sanctum library handles tests, I noticed that they
used this pattern. The pattern I ended up using is the following:

- Use the laravel helper trait
`Illuminate\Foundation\Testing\DatabaseTransactions`. This just runs
everything in a transaction that gets rolled back. I don't like this as
a test strategy for fixtures/testing actual database writes, but it
works for now.
- Create the data we need as a dependency for each test, e.g. if we need
the existence of another user's note to test that we can't view it, then
create that note in the test.

I ran into some problems with the tests actually connecting to the real
database connection, which I was surprised was possible, so I eventually
used this transaction strategy.  I'm surprised laravel will allow that
behavior by default as it could delete all of your data when running
tests if you're not careful (!)

The rest of the changes here are related to small bugs found while
creating the tests.